### PR TITLE
Add support for GNOME 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Keep pinned apps in AppGrid",
   "description": "Display your pinned/favorite applications in the AppGrid while preserving your existing Dash-to-Dock layout and arrangement.",
   "uuid": "pinned-apps-in-appgrid@brunosilva.io",
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "url": "https://github.com/brunos3d/pinned-apps-in-appgrid",
   "version": 1
 }


### PR DESCRIPTION
This is a metadata-only change.

I have been using the current release version with the metadata file manually edited on Ubuntu Plucky (dev version for 25.04) with GNOME 48 RC and it seems to be working OK.