### PR TITLE
Add GNOME 49 support to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Keep pinned apps in AppGrid",
   "description": "Display your pinned/favorite applications in the AppGrid while preserving your existing Dash-to-Dock layout and arrangement.",
   "uuid": "pinned-apps-in-appgrid@brunosilva.io",
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "url": "https://github.com/brunos3d/pinned-apps-in-appgrid",
   "version": 1
 }


### PR DESCRIPTION
Working without any changes, tested on GNOME OS Nightly