### PR TITLE
Improve drag-and-drop reliability and keep auto-hide docks visible while dragging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A GNOME Shell extension (UUID `pinned-apps-in-appgrid@brunosilva.io`) that makes favorite/pinned apps appear in the AppGrid *and* folders, while keeping them in the Dash. Since GNOME 40, favorites show only in the dock; this extension restores them to the grid without disturbing an existing Dash-to-Dock layout.
+
+All logic lives in `extension.js`. `types.d.ts` provides hand-written ambient declarations for the private GNOME Shell modules (`resource:///org/gnome/shell/...`) used for editor type-checking only — it is not compiled or shipped.
+
+## Build & install
+
+```bash
+make            # pack + install (runs the two targets below)
+make pack       # gnome-extensions pack --force  -> produces *.shell-extension.zip
+make update     # gnome-extensions install --force *.shell-extension.zip
+```
+
+After installing, log out/in (or restart GNOME Shell) and enable via `gnome-extensions enable pinned-apps-in-appgrid@brunosilva.io`. There is no test suite, linter, or build step beyond `gnome-extensions pack`. The Makefile auto-prefixes commands with `flatpak-spawn --host` when `FLATPAK_ID` is set.
+
+Supported shell versions and the version number are declared in `metadata.json`; bump `version` (an integer) when releasing.
+
+## Architecture
+
+`Extension.enable()` installs a list of "mod" objects, each of which patches GNOME Shell methods via `InjectionManager.overrideMethod` (or connects a signal) and undoes it in `clear()`. `disable()` reverses the list and clears each — order matters, so preserve the reverse-on-disable pattern. `enable()` fetches `appDisplay` fresh (not in the constructor) and wraps mod construction in a `try/catch` that rolls back via `disable()` if a private symbol is missing on a new Shell version.
+
+- **`BaseAppViewMod`** — the core trick. It overrides `_redisplay` on both `AppDisplay` and `FolderView` prototypes to swap the instance's `_appFavorites` for the **`createDummyAppFavorites()`** proxy just before the original runs. The proxy wraps the real `AppFavorites` singleton and delegates everything except `isFavorite()`, which always returns `false`. GNOME hides favorites from the grid because it thinks they're favorites; lying makes them render in both places. After redisplay it calls `folderIcon.icon.update()` on every folder icon so favorites also appear in the 2×2 folder *preview* thumbnails (fix for issue #3). (The proxy is a full wrapper, not a partial stand-in, so a future Shell calling any other `AppFavorites` method on it won't throw.)
+- **`DashMod`** — overrides `Dash.getAppFromSource` so dragging an app from the grid onto the dash doesn't create a duplicate favorite (returns `null` when the app is already a favorite), while still allowing rearrangement of existing dash icons (`DashIcon` sources pass through).
+- **`AppDisplayMod`** — overrides only the AppDisplay's `acceptDrop` so dragging a dash icon onto the grid removes it from favorites (unpins). This re-implements native behavior that `BaseAppViewMod` disables (the native path checks the now-proxied `_appFavorites.isFavorite()`), so it consults the **real** `AppFavorites`. Detects dash-origin drags including Dash-to-Panel via the GType name constant `DashToPanelIconGTypeName`. It deliberately does **not** touch `_connectDnD`/`_disconnectDnD` — the drop delegate and drag-motion handler are resolved fresh by the Shell each drag, so no reconnect is needed (a previous `_reconnectDnD` did this and caused a first-drag reordering bug + leaked signal connections).
+- **`DockVisibilityMod`** — connects to `Main.overview` `item-drag-begin`/`item-drag-end`/`item-drag-cancelled` and, for the duration of a drag, sets `requiresVisibility = true` on any auto-hide dock's dash so it stays visible while reordering. Feature-detected via the dock dash's `_requireVisibility()` method (Dash to Dock / Dash to Panel have it; the vanilla dash does not, so it no-ops on stock GNOME). Restores the prior value on drag end. This is the only mod that reaches toward third-party dock internals, and it touches only the public-by-convention `requiresVisibility` flag.
+
+Key coupling to be aware of: this extension depends on GNOME Shell **private** internals (`_appFavorites`, `_redisplay`, `_folderIcons`, `getAppFromSource`, the `Dash`/`AppIcon`/`DashIcon` classes) and the docks' `requiresVisibility` convention. These are unstable across shell versions — adding support for a new GNOME release usually means verifying these method names/shapes still exist, then adding the version string to `metadata.json`.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,41 @@
 
 ## Overview
 
-Starting with GNOME 40, favorite applications are only displayed in the dock. This extension brings them back to the application grid, allowing you to keep your pinned/favorite apps visible in both places without interfering with your existing Dash-to-Dock layout.
+Starting with GNOME 40, favorite applications are only displayed in the dock. This extension brings them back to the application grid — and into app folders — so your pinned/favorite apps stay visible in both places, without interfering with your existing Dash or Dash-to-Dock layout.
 
 https://github.com/user-attachments/assets/3b9a1c6c-a341-4e5f-accd-0d69b5a299c9
 
 ## Background
 
-This project is a fork of the [favourites\-in\-appgrid](https://gitlab.gnome.org/harshadgavali/favourites-in-appgrid/) extension. It addresses the following issues related to rearranging favorite apps in both the GNOME Dock and the GNOME Application Grid:
+This extension addresses long-standing pain points around rearranging favorite apps in both the GNOME Dock and the GNOME Application Grid:
 
-- [Dash\-to\-Dock issue #2010](https://github.com/micheleg/dash-to-dock/issues/2010)
-- [Dash\-to\-Dock issue #2122](https://github.com/micheleg/dash-to-dock/issues/2122)
+- [Dash-to-Dock issue #2010](https://github.com/micheleg/dash-to-dock/issues/2010)
+- [Dash-to-Dock issue #2122](https://github.com/micheleg/dash-to-dock/issues/2122)
 
 ## Features
 
-- Pins your favorite applications in both the GNOME dock and application grid.
-- Preserves your GNOME Dock setup and prevents unwanted rearrangements.
+- Shows your pinned/favorite apps in the Application Grid **and** inside app folders, while keeping them in the dock.
+- Never creates duplicate favorites when you drag a grid icon onto the dock.
+- Unpin an app by dragging its dock icon onto the grid, exactly like native GNOME.
+- Keeps auto-hide docks (Dash to Dock / Dash to Panel) visible while you drag, so reordering is never interrupted.
+- Preserves your dock layout and leaves the grid's ordering entirely to GNOME.
+- Works on stock GNOME as well as with Dash to Dock and Dash to Panel.
+
+## How it works
+
+The extension is intentionally small and reversible: `enable()` installs a set of independent "mods", each of which patches one GNOME Shell behavior and fully undoes it on `disable()`.
+
+- **Favorites in the grid & folders.** GNOME hides favorites from the grid by checking `AppFavorites.isFavorite()`. The extension wraps the real favorites model in a lightweight proxy that reports "not a favorite" only during the grid's redisplay, so favorites render in the grid and folders (including the small 2×2 folder previews) while the dock keeps using the real model. Your favorites data is never modified or duplicated.
+- **No duplicate pins.** Dragging a grid icon that is already pinned onto the dock is ignored instead of adding a second copy.
+- **Drag to unpin.** Dropping a dock icon onto the grid removes it from favorites, restoring the native gesture (which the proxy above would otherwise disable).
+- **Dock stays visible while dragging.** Auto-hide docks are kept on screen for the duration of a drag — via the dock's own `requiresVisibility` flag — so reordering favorites is never cut short. This is a no-op on the stock GNOME dash, which doesn't auto-hide.
+
+The grid's ordering stays entirely under GNOME's control; the extension never reorders apps for you. It relies on GNOME Shell private internals, so `enable()` rolls back cleanly if a future Shell release changes something it depends on.
+
+## Compatibility
+
+- GNOME Shell 45–50 (see `metadata.json` for the current list).
+- Works with the stock GNOME dash, **Dash to Dock**, and **Dash to Panel**.
 
 ## Installation
 

--- a/extension.js
+++ b/extension.js
@@ -212,6 +212,80 @@ class BaseAppViewMod {
   }
 }
 
+/**
+ * DockVisibilityMod - Keeps auto-hide docks visible while an item is being dragged.
+ *
+ * Vanilla GNOME's dash lives only in the overview and never auto-hides, so this is a
+ * no-op there. Auto-hide docks (Dash to Dock, and Dash to Panel which derives from it)
+ * decide their own visibility from a `requiresVisibility` flag on their dash. Some
+ * versions fail to set it during a drag (e.g. Dash to Dock intellihide re-evaluates
+ * mid-drag as the drag actor overlaps the dock), so the dock hides while the user is
+ * still dragging and reordering onto it becomes impossible.
+ *
+ * We set that flag for the duration of the drag and restore it afterwards. It only
+ * touches the `requiresVisibility` convention, gated behind feature detection (the
+ * presence of the dock's own `_requireVisibility()` method), and never reaches into a
+ * dock's private layout/animation internals. When no auto-hide dock is present it does
+ * nothing.
+ */
+class DockVisibilityMod {
+  constructor() {
+    this._changed = [];
+    this._overviewIds = [
+      Main.overview.connect('item-drag-begin', this._onDragBegin.bind(this)),
+      Main.overview.connect('item-drag-end', this._onDragEnd.bind(this)),
+      Main.overview.connect('item-drag-cancelled', this._onDragEnd.bind(this)),
+    ];
+  }
+
+  clear() {
+    this._overviewIds.forEach((id) => Main.overview.disconnect(id));
+    this._overviewIds = [];
+    // Drop any pending overrides without restoring: on disable the dock owns its
+    // own visibility again, and a drag can't be in progress across disable().
+    this._changed = [];
+  }
+
+  /**
+   * Candidate dash objects, from the most stable Shell paths, that belong to an
+   * auto-hide dock. Deduplicated. The vanilla dash is filtered out because it has no
+   * `_requireVisibility()` method and does not auto-hide.
+   */
+  _dockDashes() {
+    const candidates = [Main.overview?.dash, Main.overview?._overview?.controls?.dash];
+
+    const seen = new Set();
+    return candidates.filter((dash) => {
+      if (!dash || seen.has(dash) || typeof dash._requireVisibility !== 'function') {
+        return false;
+      }
+      seen.add(dash);
+      return true;
+    });
+  }
+
+  _onDragBegin() {
+    // Guard against a missed drag-end leaving stale state.
+    this._onDragEnd();
+
+    for (const dash of this._dockDashes()) {
+      this._changed.push([dash, dash.requiresVisibility]);
+      dash.requiresVisibility = true;
+    }
+  }
+
+  _onDragEnd() {
+    for (const [dash, previous] of this._changed) {
+      try {
+        dash.requiresVisibility = previous;
+      } catch {
+        // The dock may have been destroyed mid-drag (e.g. monitor change); ignore.
+      }
+    }
+    this._changed = [];
+  }
+}
+
 export default class Extension {
   constructor() {
     this._mods = [];
@@ -230,6 +304,7 @@ export default class Extension {
       this._mods.push(new BaseAppViewMod(this._appDisplay));
       this._mods.push(new AppDisplayMod(this._appDisplay));
       this._mods.push(new DashMod());
+      this._mods.push(new DockVisibilityMod());
     } catch (e) {
       // If any patch fails (e.g. a private Shell API changed on a new Shell
       // version), roll back everything already applied instead of leaving the

--- a/extension.js
+++ b/extension.js
@@ -216,15 +216,32 @@ export default class Extension {
   constructor() {
     this._mods = [];
     /** @type {AppDisplay.AppDisplay} */
-    this._appDisplay = Main.overview._overview.controls.appDisplay;
+    this._appDisplay = null;
   }
 
   enable() {
-    this._mods = [new BaseAppViewMod(this._appDisplay), new AppDisplayMod(this._appDisplay), new DashMod()];
+    // Fetch the appDisplay at enable() time rather than in the constructor:
+    // the extension can be enabled/disabled several times per session and the
+    // Shell may recreate the appDisplay, so a reference cached once can go stale.
+    this._appDisplay = Main.overview._overview.controls.appDisplay;
+    this._mods = [];
+
+    try {
+      this._mods.push(new BaseAppViewMod(this._appDisplay));
+      this._mods.push(new AppDisplayMod(this._appDisplay));
+      this._mods.push(new DashMod());
+    } catch (e) {
+      // If any patch fails (e.g. a private Shell API changed on a new Shell
+      // version), roll back everything already applied instead of leaving the
+      // Shell in a half-patched state.
+      logError(e, 'pinned-apps-in-appgrid: failed to enable, rolling back');
+      this.disable();
+    }
   }
 
   disable() {
     this._mods.reverse().forEach((mod) => mod.clear());
     this._mods = [];
+    this._appDisplay = null;
   }
 }

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,32 @@
 /*
- * This file is part of https://github.com/brunos3d/pinned-apps-in-appgrid.
- * It is a modified version of https://gitlab.gnome.org/harshadgavali/favourites-in-appgrid.
- * This project is licensed under the GNU General Public License v3.0.
+ * Keep Pinned Apps in AppGrid  (pinned-apps-in-appgrid@brunosilva.io)
+ * https://github.com/brunos3d/pinned-apps-in-appgrid
+ *
+ * A GNOME Shell extension that keeps favorite/pinned applications visible in the
+ * AppGrid (and inside folders) while they also remain in the Dash/Dock. Since
+ * GNOME 40 the Shell hides favorites from the grid; this extension restores them
+ * there without disturbing the Dash or an auto-hide dock layout.
+ *
+ * Licensed under the GNU General Public License v3.0. See the LICENSE file.
+ *
+ *
+ * ARCHITECTURE
+ * ------------
+ * Extension.enable() installs a list of small, independent "mods". Each mod patches
+ * one or more GNOME Shell methods through InjectionManager (or connects a signal) in
+ * its constructor and fully undoes that work in clear(). disable() clears the mods in
+ * reverse order, so every behavior change stays isolated and individually reversible.
+ *
+ *   BaseAppViewMod    - the core trick: makes favorites render in the grid and folders.
+ *   AppDisplayMod     - dropping a dash icon onto the grid unpins it (drag to remove).
+ *   DashMod           - dragging a grid icon onto the dash never creates a duplicate.
+ *   DockVisibilityMod - keeps an auto-hide dock visible for the duration of a drag.
+ *
+ * The extension leans on GNOME Shell *private* internals (_appFavorites, _redisplay,
+ * _folderIcons, getAppFromSource, the Dash/AppIcon classes, ...). These are unstable
+ * across Shell versions, so enable() is wrapped in a try/catch that rolls back cleanly
+ * if one of them is missing on a future release. Supported versions live in
+ * metadata.json.
  */
 
 /* exported Extension */
@@ -15,13 +40,25 @@ import * as DND from 'resource:///org/gnome/shell/ui/dnd.js';
 import * as AppDisplay from 'resource:///org/gnome/shell/ui/appDisplay.js';
 import * as ExtensionModule from 'resource:///org/gnome/shell/extensions/extension.js';
 
+// GType name of Dash to Panel's taskbar icons. They are not instances of the Shell's
+// DashIcon, so drag sources coming from a Dash to Panel taskbar can only be recognized
+// by their registered GObject type name. Used by AppDisplayMod._isDashIcon().
 const DashToPanelIconGTypeName = 'Gjs_dash-to-panel_jderose9_github_com_appIcons_TaskbarAppIcon';
 
 /**
- * DashMod - Handles drag and drop behavior for the Dash
+ * DashMod - Controls what a drag source resolves to when dropped on the Dash.
  *
- * Prevents duplicate favorite apps from being added to the dash when dragging
- * from the app grid. Allows rearranging icons within the dash itself.
+ * The Dash turns a drag source into an app through the static Dash.getAppFromSource();
+ * handleDragOver()/acceptDrop() then use that app to reorder or pin favorites. Because
+ * this extension puts favorite icons into the AppGrid too, a favorite can now be
+ * dragged from the grid onto the dash, which natively would add a second copy of an app
+ * that is already pinned.
+ *
+ * The override:
+ *   - lets DashIcon sources through unchanged, so reordering existing dash icons works;
+ *   - returns null for an AppGrid AppIcon whose app is already a favorite, blocking the
+ *     duplicate; a non-favorite grid icon still resolves normally so it can be pinned;
+ *   - falls back to the original behavior for any other source.
  */
 class DashMod {
   constructor() {
@@ -60,10 +97,18 @@ class DashMod {
 }
 
 /**
- * AppDisplayMod - Handles drag and drop behavior for the AppDisplay
+ * AppDisplayMod - Unpins an app when its dash icon is dropped onto the AppGrid.
  *
- * When apps from the dash are dropped onto the app display, they are removed
- * from favorites (unpinned from the dash).
+ * Dropping a dash icon on the grid is GNOME's native gesture for removing a favorite.
+ * The Shell implements it in AppDisplay.acceptDrop() by checking
+ * `this._appFavorites.isFavorite(source.id)`. BaseAppViewMod replaces that
+ * _appFavorites with a proxy whose isFavorite() always returns false, which
+ * (intentionally) makes favorites render in the grid but also disables the native
+ * unpin. This mod restores the unpin by consulting the *real* AppFavorites instead.
+ *
+ * It intentionally overrides only acceptDrop(): the drop delegate is resolved fresh by
+ * the DND machinery on every drop, and the grid's own drag-motion handler is re-bound
+ * on every drag, so nothing here needs to reconnect the AppDisplay's DnD signals.
  */
 class AppDisplayMod {
   /**
@@ -71,6 +116,7 @@ class AppDisplayMod {
    */
   constructor(appDisplay) {
     this._appDisplay = appDisplay;
+    // The real, unproxied favorites model, so unpin actually mutates the dock.
     this._appFavorites = AppFavorites.getAppFavorites();
     this._injectionManager = new ExtensionModule.InjectionManager();
 
@@ -81,6 +127,8 @@ class AppDisplayMod {
     this._injectionManager.clear();
   }
 
+  // True when the drag originates from a dock: the Shell's own DashIcon, or a
+  // Dash to Panel taskbar icon (matched by GType name since it is not a DashIcon).
   _isDashIcon(source) {
     return source instanceof DashModule.DashIcon || GObject.type_name(source) === DashToPanelIconGTypeName;
   }
@@ -92,13 +140,15 @@ class AppDisplayMod {
     /** @this {AppDisplay.AppDisplay} */
     return function (source) {
       if (mod._isDashIcon(source)) {
-        // If drop is from dash, remove app from favorites
+        // Dropped from the dock onto the grid: unpin it from favorites. Checked
+        // against the real model because the grid's _appFavorites is proxied.
         if (appFavorites.isFavorite(source.id)) {
           appFavorites.removeFavorite(source.id);
         }
         return DND.DragDropResult.SUCCESS;
       }
 
+      // Not a dock icon (e.g. moving/reordering a grid icon): keep native behavior.
       return originalMethod.call(this, source);
     };
   }
@@ -132,14 +182,20 @@ function createDummyAppFavorites() {
 }
 
 /**
- * BaseAppViewMod - Modifies AppDisplay and FolderView to show favorite apps
+ * BaseAppViewMod - The core trick: makes favorites appear in the grid and folders.
  *
- * This is the core of the extension. It:
- * 1. Replaces the _appFavorites reference with DummyAppFavorites
- * 2. Forces folder icon previews to update after redisplay
+ * The Shell excludes favorites from the AppGrid inside _loadApps() by testing
+ * _appFavorites.isFavorite(). By overriding _redisplay() on both AppDisplay and
+ * FolderView to swap in the createDummyAppFavorites() proxy (isFavorite() -> false)
+ * just before the original runs, the exclusion filter never removes anything, so
+ * favorites render in the grid and inside folders while still living in the dash.
  *
- * Without the folder icon update, favorite apps would appear inside folders when opened,
- * but would not show in the folder preview icons (the small 2x2 grid on folder icons).
+ * It also forces every folder icon to regenerate its preview after redisplay. Without
+ * that, a favorite added to a folder would show when the folder is opened but not in
+ * the small 2x2 preview thumbnail on the folder's icon (issue #3).
+ *
+ * clear() swaps the reference back to the real AppFavorites and redisplays once, so the
+ * grid returns to stock behavior before the method overrides are removed.
  */
 class BaseAppViewMod {
   /**

--- a/extension.js
+++ b/extension.js
@@ -74,33 +74,15 @@ class AppDisplayMod {
     this._appFavorites = AppFavorites.getAppFavorites();
     this._injectionManager = new ExtensionModule.InjectionManager();
 
-    this._injectionManager.overrideMethod(this._appDisplay, '_onDragMotion', this._createOnDragMotion.bind(this));
     this._injectionManager.overrideMethod(this._appDisplay, 'acceptDrop', this._createAcceptDrop.bind(this));
-
-    this._reconnectDnD();
   }
 
   clear() {
     this._injectionManager.clear();
-    this._reconnectDnD();
-  }
-
-  _reconnectDnD() {
-    this._appDisplay._disconnectDnD();
-    this._appDisplay._connectDnD();
   }
 
   _isDashIcon(source) {
     return source instanceof DashModule.DashIcon || GObject.type_name(source) === DashToPanelIconGTypeName;
-  }
-
-  _createOnDragMotion(originalMethod) {
-    const mod = this;
-
-    /** @this {AppDisplay.AppDisplay} */
-    return function (dragEvent) {
-      return originalMethod.call(mod._appDisplay, dragEvent);
-    };
   }
 
   _createAcceptDrop(originalMethod) {

--- a/extension.js
+++ b/extension.js
@@ -105,25 +105,30 @@ class AppDisplayMod {
 }
 
 /**
- * DummyAppFavorites - A proxy for AppFavorites that always returns false for isFavorite()
+ * createDummyAppFavorites - Wraps the real AppFavorites singleton in a Proxy that
+ * reports every app as NOT a favorite (isFavorite() -> false) while transparently
+ * delegating every other property and method to the real instance.
  *
  * This tricks GNOME Shell into displaying favorite apps in the app grid and folders
- * by making it think they are not favorites. This allows favorites to appear in both
- * the dash and the app grid simultaneously.
+ * (both hide anything isFavorite() reports as true) without hiding them from the dash.
+ *
+ * Wrapping instead of replacing is deliberate: a partial stand-in that only implements
+ * isFavorite()/removeFavorite() would throw the moment the Shell called any other
+ * AppFavorites method on it during redisplay. Delegating everything keeps it correct
+ * across Shell versions; only isFavorite() is intercepted.
  */
-class DummyAppFavorites {
-  constructor() {
-    this._appFavorites = AppFavorites.getAppFavorites();
-  }
+function createDummyAppFavorites() {
+  const appFavorites = AppFavorites.getAppFavorites();
 
-  isFavorite() {
-    // Always return false to allow favorites to appear in app grid
-    return false;
-  }
+  return new Proxy(appFavorites, {
+    get(target, prop, receiver) {
+      if (prop === 'isFavorite')
+        return () => false;
 
-  removeFavorite(id) {
-    return this._appFavorites.removeFavorite(id);
-  }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
 }
 
 /**
@@ -143,7 +148,7 @@ class BaseAppViewMod {
   constructor(appDisplay) {
     this._appDisplay = appDisplay;
     /** @type {AppFavorites.IAppFavorites} */
-    this._dummyAppFavorites = new DummyAppFavorites();
+    this._dummyAppFavorites = createDummyAppFavorites();
     this._injectionManager = new ExtensionModule.InjectionManager();
 
     // Override _redisplay for both FolderView and AppDisplay

--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "pinned-apps-in-appgrid@brunosilva.io",
   "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/brunos3d/pinned-apps-in-appgrid",
-  "version": 6
+  "version": 8
 }


### PR DESCRIPTION
## Summary

Reliability pass on drag-and-drop plus a new fix for auto-hide docks hiding mid-drag, followed by documentation. Each change is its own conventional commit; behavior for the core feature (favorites in the grid/folders) is unchanged.

The root-cause analysis was done against the actual GNOME Shell 50.2 source and the Dash to Dock v105 source, so the fixes target the real mechanisms rather than guesses.

## What changed

### `fix(dnd): stop force-reconnecting AppDisplay drag-and-drop`
`AppDisplayMod` used to call `_reconnectDnD()` (`_disconnectDnD()` + `_connectDnD()`) on enable. GNOME already wires the AppDisplay's `item-drag-*` handlers in `vfunc_map()` with no idempotency guard, so forcing them while the grid was still unmapped produced **duplicate, leaked signal connections** once the App Grid was first opened, and let the grid's drag machinery participate before its geometry was valid. This matches the reported symptom of **dock reordering failing until the App Grid had been opened once**. The reconnect was also unnecessary — `acceptDrop` is resolved fresh by DND and the drag-motion handler is re-bound on every drag. Removed it along with a dead pass-through `_onDragMotion` override.

### `refactor(favorites): wrap AppFavorites in a Proxy instead of a partial stub`
The dummy favorites object handed to the grid during redisplay only reimplemented `isFavorite()`/`removeFavorite()`; any other `AppFavorites` method the Shell called on it would have thrown. It's now a `Proxy` around the real singleton that **delegates everything and intercepts only `isFavorite()`** (always false). Same behavior today, no longer fragile across Shell versions.

### `refactor(lifecycle): resolve appDisplay in enable() and roll back on failure`
`appDisplay` is now fetched in `enable()` instead of the constructor (it can go stale across enable/disable cycles or Shell recreation), and mod construction is wrapped in a `try/catch` that calls `disable()` so a missing private symbol on a future Shell fails cleanly instead of leaving the Shell half-patched.

### `feat(dock): keep auto-hide docks visible while dragging`
New `DockVisibilityMod`. Auto-hide docks (Dash to Dock / Dash to Panel) decide visibility from a `requiresVisibility` flag on their dash; some versions fail to set it during a drag (Dash to Dock intellihide re-evaluates mid-drag as the drag actor overlaps the dock), so the dock hides and reordering becomes impossible. This mod sets that flag for the duration of an `item-drag` and restores it after.
- Acts at the dock's **own decision point** (`requiresVisibility`), not by fighting its animations.
- **Feature-detected** via the dock dash's `_requireVisibility()` method → safe **no-op on stock GNOME**, whose dash never auto-hides.
- Touches only the public-by-convention flag; never reaches into a dock's private layout/animation internals.

### `docs: expand code comments, refresh README, add CLAUDE.md`
- `extension.js`: module + architecture header and per-mod rationale (documents the non-obvious workarounds); no behavior change.
- `README.md`: new "How it works" + "Compatibility" sections describing the current behavior (favorites in grid & folders, no duplicate pins, drag-to-unpin, dock stays visible while dragging); demo video kept.
- `CLAUDE.md` added; upstream-fork references dropped (now maintained independently).

### `chore: bump version to 8`

## How the extension works now

`enable()` installs four small, independent, reversible mods:

| Mod | Responsibility |
|-----|----------------|
| `BaseAppViewMod` | Swaps the grid/folder `_appFavorites` for the `isFavorite()->false` Proxy during `_redisplay`, so favorites render in the grid and folders (and 2×2 folder previews). The real favorites singleton — and the dock — are untouched. |
| `AppDisplayMod` | Restores drag-a-dock-icon-to-the-grid **unpin**, consulting the real favorites (the Proxy disables the native path). |
| `DashMod` | Blocks **duplicate pins** when dragging an already-favorite grid icon onto the dock; lets dash-icon reordering through. |
| `DockVisibilityMod` | Keeps an auto-hide dock **visible during a drag**; no-op on vanilla GNOME. |

The grid's ordering stays entirely under GNOME's control.

## Testing

- `node --check` on every commit; `gnome-extensions pack` succeeds.
- Validated on **GNOME Shell 50.2 (Wayland)** with **Dash to Dock (intellihide)**.
- Manual checks after a fresh login: reorder dock favorites on the **first** drag (before opening the App Grid); dock **stays visible** through a drag with auto-hide on and hides normally afterward; favorites still show in grid + folders with correct previews; drag-to-unpin works.

> Note: DnD behavior can only be fully verified interactively (Wayland reloads extensions on re-login), so please sanity-check the flows above after logging back in.
